### PR TITLE
Add interface for prember plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,12 @@ module.exports = {
     let Merge = require('broccoli-merge-trees');
     let debug = BroccoliDebug.buildDebugCallback(`prember`);
     let ui = this.project.ui;
+    let plugins = loadPremberPlugins(this);
+
     return debug(
       new Merge([
         tree,
-        new Prerender(debug(tree, 'input'), this.premberConfig(), ui),
+        new Prerender(debug(tree, 'input'), this.premberConfig(), ui, plugins),
       ], {
         overwrite: true
       }),
@@ -29,3 +31,12 @@ module.exports = {
     );
   }
 };
+
+function loadPremberPlugins(context) {
+  let addons = context.project.addons || [];
+
+  return addons
+    .filter((addon) => addon.pkg.keywords.includes('prember-plugin'))
+    .filter((addon) => typeof addon.urlsForPrember === 'function')
+    .map((addon) => addon.urlsForPrember.bind(addon));
+}

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -11,23 +11,29 @@ const path = require('path');
 const chalk = require('chalk');
 
 class Prerender extends Plugin {
-  constructor(builtAppTree, { urls, indexFile, emptyFile }, ui) {
+  constructor(builtAppTree, { urls, indexFile, emptyFile }, ui, plugins) {
     super([builtAppTree], { name: 'prember', needsCache: false });
     this.urls = urls || [];
     this.indexFile = indexFile || 'index.html';
     this.emptyFile = emptyFile || '_empty.html';
     this.ui = ui;
+    this.plugins = plugins;
   }
 
   async listUrls(app, host) {
+    let visit = async (url) => {
+      return this._visit(app, host, url);
+    };
+
     if (typeof this.urls === 'function') {
-      let visit = async (url) => {
-        return this._visit(app, host, url);
-      };
-      return await this.urls(this.inputPaths[0], visit);
-    } else {
-      return this.urls;
+      this.urls = await this.urls(this.inputPaths[0], visit);
     }
+
+    for (let plugin of this.plugins) {
+      this.urls = this.urls.concat(await plugin(this.inputPaths[0], visit));
+    }
+
+    return this.urls;
   }
 
   async build() {
@@ -116,7 +122,6 @@ class Prerender extends Plugin {
       this.ui.writeLine(`pre-render ${url} ${chalk.red(page.statusCode)}`);
     }
   }
-
 }
 
 module.exports = Prerender;

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -98,7 +98,10 @@ class Prerender extends Plugin {
       request: {
         url,
         headers: {
-          host
+          host,
+          'x-broccoli': {
+            outputPath: this.inputPaths[0]
+          }
         }
       }
     };


### PR DESCRIPTION
This PR exposes a hook for Ember addons to register themselves as `prember-plugin`s.

When an addon with keyword `prember-plugin` implements `registerPremberUrls`, prember should add returned urls to its list of urls to visit.

Sample implementation here: https://github.com/anulman/ember-cli-hyde/commit/65bfba0b1e2cadd82d5d3840835e0f2b49875956

Questions:

- Does this look like an appropriate implementation?
- How to customize options (eg host) for a given addon’s URLs? Is this even necessary?
- Would `urlsForPrember` be a better hook name (eg like `treeForApp`)?
- How to test this?
