### PR TITLE
Allow Node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "qunitjs": "^2.4.1"
   },
   "engines": {
-    "node": "6.* || >= 7.*"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
I'm using prember to generate documentation for an addon. Some users of the addon require support for Node 4 until it's no longer LTS status.

Would you consider relaxing the engines field a little for this case?

Thanks!