### PR TITLE
adding static file server if host is localhost:4200 - fixes #12

### DIFF
--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -9,6 +9,7 @@ const readFile = denodeify(fs.readFile);
 const mkdirp = denodeify(require('mkdirp'));
 const path = require('path');
 const chalk = require('chalk');
+const express = require('express')
 
 class Prerender extends Plugin {
   constructor(builtAppTree, { urls, indexFile, emptyFile }, ui) {
@@ -67,6 +68,14 @@ class Prerender extends Plugin {
     let app = new FastBoot({
       distPath: this.inputPaths[0]
     });
+
+    if (host === 'localhost:4200') {
+      const app = express()
+
+      app.use(express.static(this.inputPaths[0]))
+
+      app.listen(4200);
+    }
 
     let hadFailures = false;
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chalk": "^2.3.0",
     "denodeify": "^1.2.1",
     "ember-cli-babel": "^6.6.0",
+    "express": "^4.16.2",
     "fastboot": "^1.1.0",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
This PR does what it says on the tin, it will add a simple static express server for local files if the host is `localhost:4200`

This doesn't solve all of the issues you brought up in #12 but it at least starts the conversation and it covers the use case that we need in the new Ember Guides-App and Deprecations-App 👍 

Let me know if you have any questions