### PR TITLE
Ensure prember runs before esw

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
+    "before": [
+      "ember-service-worker",
+      "ember-service-worker-prember"
+    ],
     "after": [
       "ember-cli-fastboot"
     ]


### PR DESCRIPTION
Without this, it is impossible to get the output of prember in esw-prember, which makes it tough to make hashes for things.