### PR TITLE
Allow Fastboot sandbox globals to be defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The supported options are:
  - `enabled`: defaults to `environment === 'production'` so that `prember` only runs during production builds.
  - `indexFile`: defaults to `"index.html"`. This is the name we will give to each of the files we create during pre-rendering.
  - `emptyFile`: defaults to `"_empty.html"`. This is where we will put a copy of your empty `index.html` as it was before any pre-rendering.
+ - `globals`: an optional map of key value pairs to expose in the Fastboot sandbox, allowing the application to define global variables to be used when pre-rendering pages.  This is useful for libraries that require a polyfill to work properly during pre-rendering.
 
 ## Using a custom URL discovery function
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,7 +12,8 @@ module.exports = function(defaults) {
     // README.
     prember: {
       enabled: true,
-      urls
+      urls,
+      globals: { foo: 'bar' }
     }
   });
 

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -15,7 +15,7 @@ const port = 7784;
 // and static assets
 
 class Prerender extends Plugin {
-  constructor(builtAppTree, { urls, indexFile, emptyFile }, ui, plugins, rootURL) {
+  constructor(builtAppTree, { urls, indexFile, emptyFile, globals }, ui, plugins, rootURL) {
     super([builtAppTree], { name: 'prember', needsCache: false });
     this.urls = urls || [];
     this.indexFile = indexFile || 'index.html';
@@ -81,7 +81,8 @@ class Prerender extends Plugin {
     await writeFile(path.join(this.outputPath, 'package.json'), JSON.stringify(pkg));
 
     let app = new FastBoot({
-      distPath: this.inputPaths[0]
+      distPath: this.inputPaths[0],
+      sandboxGlobals: this.globals
     });
 
     express()

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -25,7 +25,7 @@ class Prerender extends Plugin {
     this.rootURL = rootURL;
     this.port = port;
     this.host = `localhost:${port}`;
-
+    this.globals = globals;
   }
 
   async listUrls(app, host) {

--- a/node-tests/basic-test.js
+++ b/node-tests/basic-test.js
@@ -63,4 +63,10 @@ Qmodule('Prember', function(hooks) {
     assert.equal(doc.querySelector('link[rel=canonical]').getAttribute('href'), "/from-sample-data");
   })
 
+  test('injects globals variables', function(assert) {
+    // this test is relying on configuration in our ember-cli-build.js
+    let doc = findDocument('globals/index.html');
+    assert.equal(doc.querySelector('span').textContent, "Global variable foo is bar");
+  })
+
 });

--- a/node-tests/url-tester.js
+++ b/node-tests/url-tester.js
@@ -2,7 +2,7 @@ const jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 
 module.exports = async function({ distDir, visit }) {
-  let urls = ['/', '/redirects', '/use-static-asset'];
+  let urls = ['/', '/redirects', '/use-static-asset', '/globals'];
 
   // Here we exercise the ability to make requests against the
   // fastboot app in order to discover more urls

--- a/tests/dummy/app/controllers/globals.js
+++ b/tests/dummy/app/controllers/globals.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  globalVar: foo, //eslint-disable-line no-undef
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -20,6 +20,7 @@ Router.map(function() {
   this.route('from-sample-data');
   this.route('use-static-asset');
   this.route('redirects');
+  this.route('globals');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/globals.js
+++ b/tests/dummy/app/routes/globals.js
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  globalVar: foo, //eslint-disable-line no-undef
+});

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -4,6 +4,7 @@ import { inject } from '@ember/service';
 export default Route.extend({
   headData: inject(),
   title: 'Document Title from Index Route',
+  globalVar: foo, //eslint-disable-line no-undef
   afterModel() {
     this.set('headData.description', 'OG Description from Index Route');
   }

--- a/tests/dummy/app/templates/globals.hbs
+++ b/tests/dummy/app/templates/globals.hbs
@@ -1,0 +1,1 @@
+<span>Global variable foo is {{globalVar}}</span>


### PR DESCRIPTION
I've been working on a simple static blog that uses Prember and PouchDB(ember-pouch).  Unfortunately, PouchDB requires the presence of fetch() and Headers in the global scope, making it incompatible with Fastboot out of the box.

I added a `globals` option to Prember so that global variables can be defined for the Fastboot sandbox.  That way, for my purposes, fetch and Headers will be available for PouchDB in Node, thereby allowing my application to receive blog entry JSON from my CouchDB database before rendering the HTML.  I imagine this option will be useful to others.

A test is included, but it's looking for the presence of a string in the DOM passed through the globals option.  I couldn't think of a better way to test this feature, which is probably due to my laziness in testing with Ember, and would be open to a suggestion on how to better test the globals option.