### PR TITLE
Fixing issue with protocol

### DIFF
--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -9,7 +9,7 @@ const path = require('path');
 const chalk = require('chalk');
 const express = require('express')
 const { URL } = require('url');
-const protocol = 'http:';
+const protocol = 'http';
 const port = 7784;
 
 // We need to have some origin for the purpose of serving redirects


### PR DESCRIPTION
In #33 the protocol header was added to fix some issues with ember-fetch not being able to figure out the correct protocol to use. 

As it turns out a new bug was introduced (and you can see me trying to work around it here: https://github.com/ember-learn/ember-website/blob/master/app/adapters/application.js#L19) 

Essentially the old behaviour was that the protocol would come through as `undefined:` and now it has been updated it comes through as `http::` with a double `:`. 

I have tested this fix locally and it works 👍 