### PR TITLE
Proposal: urlsFromPrember

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,20 @@ prember: serving prerendered static HTML for /about       <--- served by prember
 
 ## Using prember from an addon
 
-Addon authors may declare urls for prember during compilation. To do so, you will want to:
+Addon authors may declare urls *for* prember during compilation. To do so, you will want to:
 
 - Add `prember-plugin` to your addon's package.json `keywords` array;
     - Consider also using package.json's `ember-addon` object to configure your addon to run `before: 'prember'`
 - Define a `urlsForPrember(distDir, visit)` function in your addon's main file;
     - This function shares an interface with the "custom URL discovery" function, as defined above; and
+- Advise your addon's users to install & configure `prember` in the host application.
+
+Addon authors may also get access to urls *from* prember. To do so, you will want to:
+
+- Add `prember-plugin` to your addon's package.json `keywords` array;
+    - Consider also using package.json's `ember-addon` object to configure your addon to run `before: 'prember'`
+- Define a `urlsFromPrember(urls)` function in your addon's main file;
+    - This function will receive the array of urls prember knows about as the only argument; and
 - Advise your addon's users to install & configure `prember` in the host application.
 
 # Deployment

--- a/index.js
+++ b/index.js
@@ -40,6 +40,13 @@ function loadPremberPlugins(context) {
 
   return addons
     .filter((addon) => addon.pkg.keywords.includes('prember-plugin'))
-    .filter((addon) => typeof addon.urlsForPrember === 'function')
-    .map((addon) => addon.urlsForPrember.bind(addon));
+    .filter((addon) => {
+      return typeof addon.urlsForPrember === 'function' || typeof addon.urlsFromPrember === 'function'
+    })
+    .map((addon) => {
+      return {
+        urlsForPrember: addon.urlsForPrember.bind(addon),
+        urlsFromPrember: addon.urlsFromPrember.bind(addon)
+      }
+    });
 }

--- a/index.js
+++ b/index.js
@@ -44,9 +44,16 @@ function loadPremberPlugins(context) {
       return typeof addon.urlsForPrember === 'function' || typeof addon.urlsFromPrember === 'function'
     })
     .map((addon) => {
-      return {
-        urlsForPrember: addon.urlsForPrember.bind(addon),
-        urlsFromPrember: addon.urlsFromPrember.bind(addon)
+      const premberPlugin = {};
+
+      if(addon.urlsForPrember){
+        premberPlugin.urlsForPrember = addon.urlsForPrember.bind(addon);
       }
+
+      if(addon.urlsFromPrember){
+        premberPlugin.urlsFromPrember = addon.urlsFromPrember.bind(addon);
+      }
+
+      return premberPlugin;
     });
 }

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -7,7 +7,7 @@ const readFile = denodeify(fs.readFile);
 const mkdirp = denodeify(require('mkdirp'));
 const path = require('path');
 const chalk = require('chalk');
-const express = require('express')
+const express = require('express');
 const { URL } = require('url');
 const protocol = 'http';
 const port = 7784;
@@ -40,7 +40,15 @@ class Prerender extends Plugin {
     }
 
     for (let plugin of this.plugins) {
-      this.urls = this.urls.concat(await plugin(this.inputPaths[0], visit));
+      if (plugin.urlsForPrember) {
+        this.urls = this.urls.concat(await plugin.urlsForPrember(this.inputPaths[0], visit));
+      }
+    }
+
+    for (let plugin of this.plugins) {
+      if (plugin.urlsFromPrember) {
+        await plugin.urlsFromPrember(this.urls);
+      }
     }
 
     return this.urls;
@@ -51,7 +59,7 @@ class Prerender extends Plugin {
     try {
       pkg = require(path.join(this.inputPaths[0], 'package.json'));
     } catch(err) {
-      throw new Error(`Unable to load package.json from within your built application. Did you forget to add ember-cli-fastboot to your app? ${err}`)
+      throw new Error(`Unable to load package.json from within your built application. Did you forget to add ember-cli-fastboot to your app? ${err}`);
     }
 
     /* Move the original "empty" index.html HTML file to an
@@ -78,8 +86,6 @@ class Prerender extends Plugin {
     pkg.fastboot.manifest.htmlFile = this.emptyFile;
 
 
-
-
     await writeFile(path.join(this.outputPath, 'package.json'), JSON.stringify(pkg));
 
     let app = new FastBoot({
@@ -95,7 +101,7 @@ class Prerender extends Plugin {
     for (let url of await this.listUrls(app, this.protocol, this.host)) {
       try {
         hadFailures = (!await this._prerender(app, this.protocol, this.host, url)) || hadFailures;
-      } catch (err) {
+      } catch(err) {
         hadFailures = true;
         this.ui.writeLine(`pre-render ${url} ${chalk.red('failed with exception')}: ${err}`);
       }
@@ -104,7 +110,7 @@ class Prerender extends Plugin {
     expressServer.close();
 
     if (hadFailures) {
-      throw new Error("Some pre-rendered URLs had failures");
+      throw new Error('Some pre-rendered URLs had failures');
     }
   }
 
@@ -131,7 +137,7 @@ class Prerender extends Plugin {
       await this._writeFile(url, html);
       this.ui.writeLine(`pre-render ${url} ${chalk.green('200 OK')}`);
       return true;
-    } else if (page.statusCode >= 300 && page.statusCode < 400){
+    } else if (page.statusCode >= 300 && page.statusCode < 400) {
       let location = page.headers.headers.location[0];
       let redirectTo = new URL(location, `http://${host}${this.rootURL}`).pathname;
       let html = `<meta http-equiv="refresh" content="0;url=${redirectTo}"><link rel="canonical" href="${redirectTo}" />`;


### PR DESCRIPTION
This would allow passing not only `urlsForPrember`, but also for prember to output `urlsFromPrember`. The code and the API might not be ideal, but I have had a need to get the urls from prember for quite awhile, so it would be great if we could get this or something like it in!

It doesn't work ideally because it does not seem to be possible to run addons `after` prember. Possibly because prember's build is async?

Ideally, we could add this in the addon:
```json
 "ember-addon": {
    "configPath": "tests/dummy/config",
    "after": [
      "prember"
    ]
  }
```
It seems to have no effect though, as my `treeForPublic` still executed before prember did its build.