### PR TITLE
use rootUrl for static files

### DIFF
--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -93,7 +93,7 @@ class Prerender extends Plugin {
     });
 
     let expressServer = express()
-      .use(express.static(this.inputPaths[0]))
+      .use(this.rootURL, express.static(this.inputPaths[0]))
       .listen(this.port);
 
     let hadFailures = false;


### PR DESCRIPTION
I'm not 100% sure what the intended behaviour is here 🤔 but if we don't host any static files that the app is trying to get under the rootUrl any requests end up failing. This behaviour is not seen when running the app in "fastboot" mode with ember-cli-fastboot and running `ember serve` so I figured it was likely that something was wrong over here

Let me know if you would like an example where this is failing for me 👍 