### PR TITLE
Make prember accept the latest FastBoot manifest schema 5

### DIFF
--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -80,10 +80,16 @@ class Prerender extends Plugin {
            find the empty index.html file.
     */
 
-    let htmlFile = await readFile(path.join(this.inputPaths[0], pkg.fastboot.manifest.htmlFile), 'utf8');
+    let fastbootManifestSchema = pkg.fastboot.schemaVersion;
+    let htmlFilename = fastbootManifestSchema < 5 ? pkg.fastboot.manifest.htmlFile : pkg.fastboot.htmlEntrypoint;
+    let htmlFile = await readFile(path.join(this.inputPaths[0], htmlFilename), 'utf8');
     await writeFile(path.join(this.outputPath, this.emptyFile), htmlFile);
     pkg = JSON.parse(JSON.stringify(pkg));
-    pkg.fastboot.manifest.htmlFile = this.emptyFile;
+    if (fastbootManifestSchema < 5) {
+      pkg.fastboot.manifest.htmlFile = this.emptyFile;
+    } else {
+      pkg.fastboot.htmlEntrypoint = this.emptyFile;
+    }
 
 
     await writeFile(path.join(this.outputPath, 'package.json'), JSON.stringify(pkg));


### PR DESCRIPTION
`Cannot read property 'htmlFile' of undefined` is what you get when running Prember w/ Embroider, due to Embroider generating a v5 manifest, which Prember is not able to understand.

Unfortunately we seem to have to make Prember aware of manifest versions, even though the intention of [fastboot-schema.js](https://github.com/ember-fastboot/fastboot/blob/429eb1d1c3d9353f3085196e71cfde416f154cba/src/fastboot-schema.js) is to abstract this away. But as we mangle the manifest, we can not rely on that. But the change here is not really changing that.