### PR TITLE
Add Embroider support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
+          - embroider-safe
+          - embroider-optimized
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This Ember addon allows you to pre-render any list of URLs into static HTML file
 - 🎯 SEO Friendly.
 - 🥇 Ember-centric developer experience.
 - 😌 Painless project setup & migration.
+- 📦 Embroider support
 
 ## Quick Start
 
@@ -191,6 +192,29 @@ Addon authors may also get access to urls *from* prember. To do so, you will wan
 - Define a `urlsFromPrember(urls)` function in your addon's main file;
     - This function will receive the array of urls prember knows about as the only argument; and
 - Advise your addon's users to install & configure `prember` in the host application.
+
+## Using prember with Embroider
+
+You can use prember in an Embroider-based build, however you must apply some changes to your `ember-cli-build.js` for it to work. 
+Embroider does not support the `postprocessTree` (type `all`) hook that this addon uses to *implicitly* hook into the build pipeline.
+But it exposes a `prerender` function to do so *explicitly*. 
+
+In a typical Embroider setup, your `ember-cli-build.js` will look like this:
+
+```js
+const { Webpack } = require('@embroider/webpack');
+return require('@embroider/compat').compatBuild(app, Webpack);
+```
+
+For prember to add its prerendered HTML pages on top of what Embroider already emitted, wrap the compiled output with the `prerender` function like this:
+
+```diff
+const { Webpack } = require('@embroider/webpack');
+- return require('@embroider/compat').compatBuild(app, Webpack);
++ const compiledApp = require('@embroider/compat').compatBuild(app, Webpack);
++ 
++ return require('prember').prerender(app, compiledApp);
+```
 
 # Deployment
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,7 +25,7 @@ module.exports = function (defaults) {
   });
 
   if ('@embroider/core' in app.dependencies()) {
-    return require('prember').prerender(app, appTree);
+    return require('./index').prerender(app, appTree);
   } else {
     return appTree;
   }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,11 +16,17 @@ module.exports = function (defaults) {
   });
 
   const { maybeEmbroider } = require('@embroider/test-setup');
-  return maybeEmbroider(app, {
+  const appTree = maybeEmbroider(app, {
     skipBabel: [
       {
         package: 'qunit',
       },
     ],
   });
+
+  if ('@embroider/core' in app.dependencies()) {
+    return require('prember').prerender(app, appTree);
+  } else {
+    return appTree;
+  }
 };

--- a/index.js
+++ b/index.js
@@ -20,10 +20,14 @@ module.exports = {
    * don't support the `postprocessTree('all', tree)` hook used here.
    */
   prerender(app, tree) {
-    let premberAddon = app.project.addons.find(({ name }) => name === 'prember');
+    let premberAddon = app.project.addons.find(
+      ({ name }) => name === 'prember'
+    );
 
     if (!premberAddon) {
-      throw new Error('Could not find initialized prember addon. It must be part of your app\'s dependencies!');
+      throw new Error(
+        "Could not find initialized prember addon. It must be part of your app's dependencies!"
+      );
     }
 
     return premberAddon._prerenderTree(tree);
@@ -43,12 +47,21 @@ module.exports = {
     let plugins = loadPremberPlugins(this);
 
     return debug(
-      new Merge([
-        tree,
-        new Prerender(debug(tree, 'input'), config, ui, plugins, this._rootURL),
-      ], {
-        overwrite: true
-      }),
+      new Merge(
+        [
+          tree,
+          new Prerender(
+            debug(tree, 'input'),
+            config,
+            ui,
+            plugins,
+            this._rootURL
+          ),
+        ],
+        {
+          overwrite: true,
+        }
+      ),
       'output'
     );
   },

--- a/index.js
+++ b/index.js
@@ -7,8 +7,31 @@ module.exports = {
   premberConfig,
 
   postprocessTree(type, tree) {
+    if (type !== 'all') {
+      return tree;
+    }
+
+    return this._prerenderTree(tree);
+  },
+
+  /**
+   * This function is *not* called by ember-cli directly, but supposed to be imported by an app to wrap the app's
+   * tree, to add the prerendered HTML files. This workaround is currently needed for Embroider-based builds that
+   * don't support the `postprocessTree('all', tree)` hook used here.
+   */
+  prerender(app, tree) {
+    let premberAddon = app.project.addons.find(({ name }) => name === 'prember');
+
+    if (!premberAddon) {
+      throw new Error('Could not find initialized prember addon. It must be part of your app\'s dependencies!');
+    }
+
+    return premberAddon._prerenderTree(tree);
+  },
+
+  _prerenderTree(tree) {
     let config = this.premberConfig();
-    if (type !== 'all' || !config.enabled) {
+    if (!config.enabled) {
       return tree;
     }
 
@@ -20,21 +43,12 @@ module.exports = {
     let plugins = loadPremberPlugins(this);
 
     return debug(
-      new Merge(
-        [
-          tree,
-          new Prerender(
-            debug(tree, 'input'),
-            this.premberConfig(),
-            ui,
-            plugins,
-            this._rootURL
-          ),
-        ],
-        {
-          overwrite: true,
-        }
-      ),
+      new Merge([
+        tree,
+        new Prerender(debug(tree, 'input'), config, ui, plugins, this._rootURL),
+      ], {
+        overwrite: true
+      }),
       'output'
     );
   },


### PR DESCRIPTION
Given that `postprocessTree('all', tree)` is not supported in an Embroider-based build, this adds a `prerender` export that users can use to wrap their final app tree to add the prerendered HTML files, in a way as suggested in https://github.com/ef4/prember/issues/59#issuecomment-720225598:

```
// ember-cli-build.js
const { Webpack } = require('@embroider/webpack');
const compiledApp = require('@embroider/compat').compatBuild(app, Webpack, {
  // ...
});

return require('prember').prerender(app, compiledApp);
```

~This is still a WIP, would like to get feedback/approval for that approach first, then:~
* ~add some documentation~
* ~setup Embroider test scenarios, after #63 is merged~
* ~rebase when #61 is merged (this is still included here)~

Closes #59 