### PR TITLE
add option to skip render

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
     return debug(
       new Merge([
         tree,
-        new Prerender(debug(tree, 'input'), this.premberConfig(), ui, plugins, this._rootURL),
+        new Prerender(debug(tree, 'input'), config, ui, plugins, this._rootURL),
       ], {
         overwrite: true
       }),

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -16,7 +16,7 @@ const port = 7784;
 // and static assets
 
 class Prerender extends Plugin {
-  constructor(builtAppTree, { urls, indexFile, emptyFile }, ui, plugins, rootURL) {
+  constructor(builtAppTree, { urls, indexFile, emptyFile, skipRender }, ui, plugins, rootURL) {
     super([builtAppTree], { name: 'prember', needsCache: false });
     this.urls = urls || [];
     this.indexFile = indexFile || 'index.html';
@@ -27,7 +27,7 @@ class Prerender extends Plugin {
     this.protocol = protocol;
     this.port = port;
     this.host = `localhost:${port}`;
-
+    this.skipRender = skipRender;
   }
 
   async listUrls(app, protocol, host) {
@@ -55,6 +55,19 @@ class Prerender extends Plugin {
   }
 
   async build() {
+    let app = new FastBoot({
+      distPath: this.inputPaths[0]
+    });
+
+    // This will call the prember-plugins api.
+    let urls = await this.listUrls(app, this.protocol, this.host);
+
+    if (this.skipRender === true) {
+      this.ui.writeLine(`skipping pre-render: plugins run.`);
+      return;
+    }
+
+
     let pkg;
     try {
       pkg = require(path.join(this.inputPaths[0], 'package.json'));
@@ -88,17 +101,13 @@ class Prerender extends Plugin {
 
     await writeFile(path.join(this.outputPath, 'package.json'), JSON.stringify(pkg));
 
-    let app = new FastBoot({
-      distPath: this.inputPaths[0]
-    });
-
     let expressServer = express()
       .use(this.rootURL, express.static(this.inputPaths[0]))
       .listen(this.port);
 
     let hadFailures = false;
 
-    for (let url of await this.listUrls(app, this.protocol, this.host)) {
+    for (let url of urls) {
       try {
         hadFailures = (!await this._prerender(app, this.protocol, this.host, url)) || hadFailures;
       } catch(err) {


### PR DESCRIPTION
This PR adds a config option to skip pre rendering.  

You may ask "why would anyone want to skip the primary function of this addon".   Well for our use case we would like to use prember to pre render our website but we are not ready yet.  While we are in transition it would be nice to enable prember to utilize some of the prember-addons.  Specifically the [prember-sitemap-generator](https://github.com/shipshapecode/prember-sitemap-generator).

Setting `skipRender` to true will run all the plugins and then stop short of rendering each page.

Thanks!


