### PR TITLE
Run after ember-auto-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "configPath": "tests/dummy/config",
     "after": [
       "ember-cli-fastboot",
-      "ember-engines"
+      "ember-engines",
+      "ember-auto-import"
     ],
     "before": [
       "broccoli-asset-rev"


### PR DESCRIPTION
ember-auto-import 2.0 started using postprocessTree(all). Since we do too, and we need its output, we need to declare that we come after.