### PR TITLE
add option to pass in buildSandboxGlobals function

### DIFF
--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -18,7 +18,7 @@ const port = 7784;
 class Prerender extends Plugin {
   constructor(
     builtAppTree,
-    { urls, indexFile, emptyFile },
+    { urls, indexFile, emptyFile, buildSandboxGlobals },
     ui,
     plugins,
     rootURL
@@ -33,6 +33,7 @@ class Prerender extends Plugin {
     this.protocol = protocol;
     this.port = port;
     this.host = `localhost:${port}`;
+    this.buildSandboxGlobals = buildSandboxGlobals;
   }
 
   async listUrls(app, protocol, host) {
@@ -111,9 +112,15 @@ class Prerender extends Plugin {
       JSON.stringify(pkg)
     );
 
-    let app = new FastBoot({
-      distPath: this.inputPaths[0],
-    });
+    let fastBootConfig = {
+      distPath: this.inputPaths[0]
+    }
+
+    if (this.buildSandboxGlobals) {
+      fastBootConfig.buildSandboxGlobals = this.buildSandboxGlobals;
+    }
+
+    let app = new FastBoot(fastBootConfig);
 
     let expressServer = express()
       .use(this.rootURL, express.static(this.inputPaths[0]))

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -113,8 +113,8 @@ class Prerender extends Plugin {
     );
 
     let fastBootConfig = {
-      distPath: this.inputPaths[0]
-    }
+      distPath: this.inputPaths[0],
+    };
 
     if (this.buildSandboxGlobals) {
       fastBootConfig.buildSandboxGlobals = this.buildSandboxGlobals;


### PR DESCRIPTION
This PR fixes issue #76 by exposing a bildSandoxGlobals config option in prember.

```
//ember-cli-build.js

const EmberApp = require('ember-cli/lib/broccoli/ember-app');
const environment = EmberApp.env();
const fastBootConfig = require('./config/fastboot.js')

module.exports = function (defaults) {
  let app = new EmberApp(defaults, {
    prember: {
      buildSandboxGlobals: fastBootConfig(environment).buildSandboxGlobals
    }
  }
 return app.toTree();
}

```