### PR TITLE
apply config/fastboot.js the same way that ember-cli-fastboot does

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
 'use strict';
 
 const premberConfig = require('./lib/config');
+const path = require('path');
+const fs = require('fs');
 
 module.exports = {
   name: require('./package').name,
   premberConfig,
+
+  included(app) {
+    this.fastbootOptions = fastbootOptionsFor(app.env, app.project);
+  },
 
   postprocessTree(type, tree) {
     if (type !== 'all') {
@@ -38,6 +44,8 @@ module.exports = {
     if (!config.enabled) {
       return tree;
     }
+
+    config.fastbootOptions = this.fastbootOptions;
 
     let Prerender = require('./lib/prerender');
     let BroccoliDebug = require('broccoli-debug');
@@ -95,4 +103,16 @@ function loadPremberPlugins(context) {
 
       return premberPlugin;
     });
+}
+
+function fastbootOptionsFor(environment, project) {
+  const configPath = path.join(
+    path.dirname(project.configPath()),
+    'fastboot.js'
+  );
+
+  if (fs.existsSync(configPath)) {
+    return require(configPath)(environment);
+  }
+  return {};
 }

--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -15,7 +15,7 @@ const port = 7784;
 class Prerender extends Plugin {
   constructor(
     builtAppTree,
-    { urls, indexFile, emptyFile },
+    { urls, indexFile, emptyFile, fastbootOptions },
     ui,
     plugins,
     rootURL
@@ -30,6 +30,7 @@ class Prerender extends Plugin {
     this.protocol = protocol;
     this.port = port;
     this.host = `localhost:${port}`;
+    this.fastbootOptions = fastbootOptions || {};
   }
 
   async listUrls(app, protocol, host) {
@@ -108,9 +109,11 @@ class Prerender extends Plugin {
       JSON.stringify(pkg)
     );
 
-    let app = new FastBoot({
-      distPath: this.inputPaths[0],
-    });
+    let app = new FastBoot(
+      Object.assign({}, this.fastbootOptions, {
+        distPath: this.inputPaths[0],
+      })
+    );
 
     let expressServer = express()
       .use(this.rootURL, express.static(this.inputPaths[0]))


### PR DESCRIPTION
This lifts the implementation for discovering a `config/fastboot.js` file directly from ember-cli-fastboot: https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/packages/ember-cli-fastboot/index.js#L386

Essentially since EmberData 4.12 you can't use prember because you need to provide a bunch of globals like `AbortController` and we aren't currently loading the `fastboot.js` config file that works with ember-cli-fastboot so it's impossible to run. 

This will also fix https://github.com/ef4/prember/pull/77 and https://github.com/ef4/prember/pull/25 because you would just configure the sandbox globals the same way that ember-cli-fastboot tells you to 👍 

Fixes https://github.com/ef4/prember/pull/77
Fixes https://github.com/ef4/prember/pull/25
Fixes https://github.com/ef4/prember/issues/76
